### PR TITLE
Unpining version numbers & streamlining deps.

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -10,22 +10,24 @@ channels:
 
 dependencies:
   - autopep8
+  - autoflake
   - black
-  - cudatoolkit=10.*
+  - cudatoolkit
   - flake8
+  - isort
   - jupyter
   - matplotlib
   - numpy
   - pillow
   - pip
   - pip:
-    - pyro-ppl>=1.2.0
+    - pyro-ppl
     - torchtestcase
     - -e .  # install package in development mode
   - pytest
   - pytest-pep8
-  - python=3.7
-  - pytorch=1.4.*
+  - python
+  - pytorch
   - pyyaml
   - rope
   - scikit-learn

--- a/setup.py
+++ b/setup.py
@@ -10,16 +10,19 @@ setup(
     author="Conor Durkan",
     packages=find_packages(exclude=["tests"]),
     license="GPLv3",
-    test_requires=["pytest", "deepdiff", "torchtestcase"],
     install_requires=[
         "matplotlib",
         "numpy",
+        "pillow",
         "pyro-ppl",
         "scipy",
         "tensorboard",
         "torch",
         "tqdm",
     ],
-    extras_requires={"dev": ["autoflake", "black", "flake8", "isort", "pytest"]},
+    extras_requires={
+        "dev": ["autoflake", "black", "flake8", "isort", "pyyaml"],
+        "testing": ["pytest", "deepdiff", "torchtestcase"],
+    },
     dependency_links=[],
 )


### PR DESCRIPTION
* No version pining in environment.yml
        - install possible for people on OSX which does not have cudatoolkit10
        - may make easier travis
* Moved test_requires (should be anyways tests_require) into an extras_requires as per https://stackoverflow.com/a/27271396 and to match 'dev' entry by Jan-Matthis (may make easier for pip users)
* Future work: consider splitting environment.yml into release, development and test environments.

Closes #9.